### PR TITLE
Added fallback "Airflow_Temperature_Cel" for ata parser

### DIFF
--- a/hddtemp-lt
+++ b/hddtemp-lt
@@ -62,6 +62,8 @@ EOF
 temp_ata() {
     if [[ $1 == *'Temperature_Celsius'* ]]; then
         read -r _ _ _ _ _ _ _ _ _ temp <<< "$1"
+    elif [[ $1 == *'Airflow_Temperature_Cel'* ]]; then
+        read -r _ _ _ _ _ _ _ _ _ temp <<< "$1"
     fi
 }
 


### PR DESCRIPTION
Added fallback "Airflow_Temperature_Cel" for ata parser.
For example: Samsung SSD 850 EVO 250GB does not have smart entry "194 Temperature_Celsius"

```
smartctl -i -A /dev/sdd
smartctl 7.2 2020-12-30 r5155 [x86_64-linux-5.15.0-92-generic] (local build)
Copyright (C) 2002-20, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Samsung based SSDs
Device Model:     Samsung SSD 850 EVO 250GB
LU WWN Device Id: 5 002538 d4060b32f
Firmware Version: EMT02B6Q
User Capacity:    250 059 350 016 bytes [250 GB]
Sector Size:      512 bytes logical/physical
Rotation Rate:    Solid State Device
TRIM Command:     Available
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-2, ATA8-ACS T13/1699-D revision 4c
SATA Version is:  SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)
Local Time is:    Mon Jan 29 03:32:49 2024 EET
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART Attributes Data Structure revision number: 1
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAG     VALUE WORST THRESH TYPE      UPDATED  WHEN_FAILED RAW_VALUE
  5 Reallocated_Sector_Ct   0x0033   100   100   010    Pre-fail  Always       -       0
  9 Power_On_Hours          0x0032   092   092   000    Old_age   Always       -       37706
 12 Power_Cycle_Count       0x0032   097   097   000    Old_age   Always       -       2543
177 Wear_Leveling_Count     0x0013   048   048   000    Pre-fail  Always       -       1105
179 Used_Rsvd_Blk_Cnt_Tot   0x0013   100   100   010    Pre-fail  Always       -       0
181 Program_Fail_Cnt_Total  0x0032   100   100   010    Old_age   Always       -       0
182 Erase_Fail_Count_Total  0x0032   100   100   010    Old_age   Always       -       0
183 Runtime_Bad_Block       0x0013   100   100   010    Pre-fail  Always       -       0
187 Uncorrectable_Error_Cnt 0x0032   100   100   000    Old_age   Always       -       0
190 Airflow_Temperature_Cel 0x0032   072   042   000    Old_age   Always       -       28
195 ECC_Error_Rate          0x001a   200   200   000    Old_age   Always       -       0
199 CRC_Error_Count         0x003e   100   100   000    Old_age   Always       -       0
235 POR_Recovery_Count      0x0012   099   099   000    Old_age   Always       -       1446
241 Total_LBAs_Written      0x0032   099   099   000    Old_age   Always       -       92790364957
```