### PR TITLE
Add --classic-tcp parameter to replicate hddtemp TCP socket output

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,7 +29,7 @@ Without any disk arguments, show temperature for all sd and nvme disks.
 - =-q= :: Suppress warnings
 - =-V, --version= :: Show version
 - =--classic= :: Replicate output format of the original hddtemp
-- =--classic-tcp= :: Replicate output format of the TCP daemon of the original hddtemp
+- =--classic-tcp= :: Replicate TCP daemon output format of the original hddtemp
 - =--hint path= :: Provide a file containing =smartctl --scan-open= output as a
   hint for device types (=-d= option value for =smartctl=)
 - =-u, --units C|F= :: Use Celsius (default) or Fahrenheit scale
@@ -70,8 +70,8 @@ Sample /classic/ output:
 
 When =--classic-tcp= is applied:
 - output is not aligned, fields are separated with a pipe
-- there is no newline between the drives
-- scale marker is added
+- there are no newlines
+- units marker is a separate field
 
 Sample /classic-tcp/ output:
 
@@ -79,6 +79,12 @@ Sample /classic-tcp/ output:
   > sudo hddtemp-lt --classic-tcp
   |/dev/sda|WDC WD10EFRX-68FYTN0|28|C||/dev/nvme0|Samsung SSD 950 PRO 256GB|40|C|
 #+end_example
+
+Under [[systemd][systemd/]] you can find basic systemd unit files to run a hddtemp-compatible
+tcp server on port =7634=.
+
+*Notice*: =hddtemp-lt@.service= assumes the tool is installed into
+=/opt/hddtemp=.
 
 * Installation
 

--- a/README.org
+++ b/README.org
@@ -29,6 +29,7 @@ Without any disk arguments, show temperature for all sd and nvme disks.
 - =-q= :: Suppress warnings
 - =-V, --version= :: Show version
 - =--classic= :: Replicate output format of the original hddtemp
+- =--classic-tcp= :: Replicate output format of the TCP daemon of the original hddtemp
 - =--hint path= :: Provide a file containing =smartctl --scan-open= output as a
   hint for device types (=-d= option value for =smartctl=)
 - =-u, --units C|F= :: Use Celsius (default) or Fahrenheit scale
@@ -65,6 +66,18 @@ Sample /classic/ output:
   > sudo hddtemp-lt --classic
   /dev/sda: WDC WD10EFRX-68FYTN0: 28°C
   /dev/nvme0: Samsung SSD 950 PRO 256GB: 40°C
+#+end_example
+
+When =--classic-tcp= is applied:
+- output is not aligned, fields are separated with a pipe
+- there is no newline between the drives
+- scale marker is added
+
+Sample /classic-tcp/ output:
+
+#+begin_example
+  > sudo hddtemp-lt --classic-tcp
+  |/dev/sda|WDC WD10EFRX-68FYTN0|28|C||/dev/nvme0|Samsung SSD 950 PRO 256GB|40|C|
 #+end_example
 
 * Installation

--- a/hddtemp-lt
+++ b/hddtemp-lt
@@ -7,7 +7,7 @@
 
 set -eu
 
-SCRIPT_VERSION=0.2.5
+SCRIPT_VERSION=0.2.5+tcp
 SCRIPT_SELF=${BASH_SOURCE[0]##*/}
 
 if [[ -t 2 ]]; then
@@ -56,6 +56,7 @@ Options:
   -V, --version              Show version
 
   --classic                  Replicate output format of the original hddtemp
+  --classic-tcp              Replicate output format of the TCP daemon of the original hddtemp
   --hint path                Provide a file containing 'smartctl --scan-open'
                              output as a hint for device types (-d option value
                              for smartctl)
@@ -157,10 +158,10 @@ main() {
     local opts
 
     # jetopt .classic .hint: hhelp q uunits: Vversion
-    opts=$(getopt -o hqu:V -l classic,hint:,help,units:,version -- "$@") || exit
+    opts=$(getopt -o hqu:V -l classic,classic-tcp,hint:,help,units:,version -- "$@") || exit
     eval set -- "$opts"
 
-    local units=C classic=n scale= hint=
+    local units=C mode=default scale= hint=
 
     while (( $# )); do
         case $1 in
@@ -170,7 +171,11 @@ main() {
                 version ;;
 
             --classic)
-                classic=y
+                mode=classic
+                shift ;;
+
+            --classic-tcp)
+                mode=tcp
                 shift ;;
 
             --hint)
@@ -210,7 +215,7 @@ main() {
         parse_hint hint_map < "$hint"
     fi
 
-    if [[ $classic == y ]]; then
+    if [[ $mode == classic ]]; then
         # The degree symbol in the current locale.
         scale=$(iconv -c -f utf-8 <<< $'\xc2\xb0')
 
@@ -282,13 +287,21 @@ main() {
             fi
         fi
 
-        items+=("${disk}:" "${name:-?}" "${temp:-?}${temp:+$scale}")
+        if [[ $mode == tcp ]]; then
+            items+=("${disk}" "${name:-?}" "${temp:-?}" "${units}")
+        else
+            items+=("${disk}:" "${name:-?}" "${temp:-?}" "${temp:+$scale}")
+        fi
     done
 
-    if [[ $classic = n ]]; then
-        printf "%-$((l_disk+1))s  %-${l_name}s  %s\n" "${items[@]}"
+    if [[ $mode == default ]]; then
+        printf "%-$((l_disk+1))s  %-${l_name}s  %s%s\n" "${items[@]}"
+    elif  [[ $mode == classic ]]; then
+        printf "%s %s: %s%s\n" "${items[@]}"
+    elif  [[ $mode == tcp ]]; then
+        printf "|%s|%s|%s|%s|" "${items[@]}"
     else
-        printf "%s %s: %s\n" "${items[@]}"
+        bye "Unknown output mode"
     fi
 }
 

--- a/hddtemp-lt
+++ b/hddtemp-lt
@@ -7,7 +7,7 @@
 
 set -eu
 
-SCRIPT_VERSION=0.2.5+tcp
+SCRIPT_VERSION=0.2.5+git
 SCRIPT_SELF=${BASH_SOURCE[0]##*/}
 
 if [[ -t 2 ]]; then
@@ -56,7 +56,9 @@ Options:
   -V, --version              Show version
 
   --classic                  Replicate output format of the original hddtemp
-  --classic-tcp              Replicate output format of the TCP daemon of the original hddtemp
+  --classic-tcp              Replicate TCP daemon output format of the original
+                             hddtemp
+
   --hint path                Provide a file containing 'smartctl --scan-open'
                              output as a hint for device types (-d option value
                              for smartctl)
@@ -157,7 +159,7 @@ parse_hint() {
 main() {
     local opts
 
-    # jetopt .classic .hint: hhelp q uunits: Vversion
+    # jetopt .classic .classic-tcp .hint: hhelp q uunits: Vversion
     opts=$(getopt -o hqu:V -l classic,classic-tcp,hint:,help,units:,version -- "$@") || exit
     eval set -- "$opts"
 
@@ -242,7 +244,7 @@ main() {
     fi
 
     local items=() l_disk=0 l_name=1
-    local disk name temp lines line parser extra
+    local disk name temp lines line parser extra _units
     for disk; do
         [[ $disk == /dev/* ]] || continue
 
@@ -287,22 +289,33 @@ main() {
             fi
         fi
 
-        if [[ $mode == tcp ]]; then
-            items+=("${disk}" "${name:-?}" "${temp:-?}" "${units}")
-        else
-            items+=("${disk}:" "${name:-?}" "${temp:-?}" "${temp:+$scale}")
-        fi
+        case $mode in
+            classic)
+                items+=("${disk}" "${name:-?}" "${temp:-?}" "${temp:+$scale}") ;;
+            tcp)
+                # daemon.c from the original tool:
+                # - when the temp is not available, print the reason (NA, UNK,
+                # NOS, SLP, ERR) in the temp column and '*' in the units
+                # column. Let the reason be NA here
+                # - when the model is not detected, print '???'
+
+                _units=$units
+                [[ -n $temp ]] || _units='*'
+
+                items+=("${disk}" "${name:-???}" "${temp:-NA}" "$_units") ;;
+            *)
+                items+=("${disk}:" "${name:-?}" "${temp:-?}" "${temp:+$scale}") ;;
+        esac
     done
 
-    if [[ $mode == default ]]; then
-        printf "%-$((l_disk+1))s  %-${l_name}s  %s%s\n" "${items[@]}"
-    elif  [[ $mode == classic ]]; then
-        printf "%s %s: %s%s\n" "${items[@]}"
-    elif  [[ $mode == tcp ]]; then
-        printf "|%s|%s|%s|%s|" "${items[@]}"
-    else
-        bye "Unknown output mode"
-    fi
+    case $mode in
+        classic)
+            printf "%s: %s: %s%s\n" "${items[@]}" ;;
+        tcp)
+            printf "|%s|%s|%s|%s|" "${items[@]}" ;;
+        *)
+            printf "%-$((l_disk+1))s  %-${l_name}s  %s%s\n" "${items[@]}" ;;
+    esac
 }
 
 [[ ! ${BASH_SOURCE[0]##*/} == "${0##*/}" ]] || main "$@"

--- a/systemd/hddtemp-lt.socket
+++ b/systemd/hddtemp-lt.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=hddtemp-lt socket
+
+[Socket]
+ListenStream=7634
+Accept=yes
+IPAddressDeny=any
+IPAddressAllow=127.0.0.1
+
+[Install]
+WantedBy=sockets.target

--- a/systemd/hddtemp-lt@.service
+++ b/systemd/hddtemp-lt@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=hddtemp-lt service
+Requires=hddtemp-lt.socket
+
+[Service]
+Type=simple
+ExecStart=/opt/hddtemp/hddtemp-lt --classic-tcp
+StandardInput=socket
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds `classic-tcp` parameter which outputs in the format of the hddtemp daemon that the legacy tool offered.

It can fully replace the previous setup using a systemd socket:

`/etc/systemd/system/hddtemp.socket`:

```
[Unit]
Description=hddtemp-lt Socket

[Socket]
ListenStream=[::]:7634
Accept=yes
IPAddressDeny=any
IPAddressAllow=127.0.0.1

[Install]
WantedBy=sockets.target
```

`/etc/systemd/system/hddtemp@.service`:

```
[Unit]
Description=hddtemp-lt Service
Requires=hddtemp.socket

[Service]
Type=simple
ExecStart=/opt/hddtemp/hddtemp-lt --classic-tcp
StandardInput=socket
StandardError=journal
TimeoutStopSec=5

[Install]
WantedBy=multi-user.target
```